### PR TITLE
Adding Travis-CI and pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,6 @@
 ^tdor.*\.tgz$
 ^doc$
 ^Meta$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.travis\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tdor*.tar.gz
 tdor*.tgz
 doc
 Meta
+docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages
+warnings_are_errors: true
+sudo: false
+cache: packages
+os:
+ - linux
+r:
+ - devel
+before_deploy: Rscript -e 'remotes::install_cran("pkgdown"); covr::codecov();'
+git:
+   depth: 9999999
+deploy:
+  provider: script
+  script: Rscript -e 'pkgdown::deploy_site_github()'
+  skip_cleanup: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,5 +25,6 @@ Suggests:
     lubridate,
     maps,
     rmarkdown,
-    stringr
+    stringr,
+    pkgdown
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ License: CC0
 Encoding: UTF-8
 LazyData: true
 Depends: R (>= 2.10)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0
 Suggests: 
     dplyr,
     gganimate,
@@ -24,5 +24,6 @@ Suggests:
     knitr,
     lubridate,
     maps,
-    rmarkdown
+    rmarkdown,
+    stringr
 VignetteBuilder: knitr

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,9 @@ knitr::opts_chunk$set(
   out.width = "100%"
 )
 ```
-
+  <!-- badges: start -->
+  [![Travis build status](https://travis-ci.org/CaRdiffR/tdor.svg?branch=master)](https://travis-ci.org/CaRdiffR/tdor)
+  <!-- badges: end -->
 # tdor
 
 **tdor** provides data on killings and suicides of transgender people, as 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,1 @@
+destination: docs


### PR DESCRIPTION
This pull request does the updates to the local packages files necessary to fix #23 and fix #24 however it does require some additional work of this workflow: CaRdiffR would need to turn on travis-ci (you can do this at https://travis-ci.org/profile/CaRdiffR), enable the gh-pages branch on github, and then allow travis to push to github. 

You can do much of that by running the following commands in R:
`usethis::use_travis()`
`usethis::use_pkgdown_travis()`
